### PR TITLE
Remove unsupportedFields on Snapshot Metadata

### DIFF
--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -28,7 +28,7 @@ class SnapshotMetadata extends FileInfoMetadataBase
             new All([
                 new Collection(
                     [
-                        'fields' => static::getVersionConstraints(),
+                        'fields' => static::getSnapshotMetaConstraints(),
                         'allowExtraFields' => true,
                     ]
                 ),
@@ -36,4 +36,31 @@ class SnapshotMetadata extends FileInfoMetadataBase
         ]);
         return $options;
     }
+    
+    /**
+	 * Returns the fields required or optional for a snapshot meta file
+	 *
+	 * @return array
+	 */
+	private static function getSnapshotMetaConstraints()
+	{
+		return [
+			'version' => [
+				new Type(['type' => 'integer']),
+				new GreaterThanOrEqual(1),
+			],
+			new Optional(
+				[
+				new Collection(
+					[
+					'length' => [
+						new Type(['type' => 'integer']),
+						new GreaterThanOrEqual(1),
+					],
+					] + static::getHashesConstraints()
+				),
+				]
+			),
+		];
+	}
 }

--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -4,6 +4,8 @@ namespace Tuf\Metadata;
 
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Count;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Type;
 use Tuf\Constraints\Collection;
@@ -36,31 +38,31 @@ class SnapshotMetadata extends FileInfoMetadataBase
         ]);
         return $options;
     }
-    
+
     /**
-	 * Returns the fields required or optional for a snapshot meta file
-	 *
-	 * @return array
-	 */
-	private static function getSnapshotMetaConstraints()
-	{
-		return [
-			'version' => [
-				new Type(['type' => 'integer']),
-				new GreaterThanOrEqual(1),
-			],
-			new Optional(
-				[
-				new Collection(
-					[
-					'length' => [
-						new Type(['type' => 'integer']),
-						new GreaterThanOrEqual(1),
-					],
-					] + static::getHashesConstraints()
-				),
-				]
-			),
-		];
-	}
+     * Returns the fields required or optional for a snapshot meta file
+     *
+     * @return array
+     */
+    private static function getSnapshotMetaConstraints()
+    {
+        return [
+            'version' => [
+                new Type(['type' => 'integer']),
+                new GreaterThanOrEqual(1),
+            ],
+            new Optional(
+                [
+                new Collection(
+                    [
+                    'length' => [
+                        new Type(['type' => 'integer']),
+                        new GreaterThanOrEqual(1),
+                    ],
+                    ] + static::getHashesConstraints()
+                ),
+                ]
+            ),
+        ];
+    }
 }

--- a/src/Metadata/SnapshotMetadata.php
+++ b/src/Metadata/SnapshotMetadata.php
@@ -29,10 +29,6 @@ class SnapshotMetadata extends FileInfoMetadataBase
                 new Collection(
                     [
                         'fields' => static::getVersionConstraints(),
-                        // These fields are mentioned in the specification as optional but the Python library does not
-                        // add these fields. Since we use the Python library for our fixtures we cannot create test
-                        // fixtures that have these fields specified.
-                        'unsupportedFields' => ['length', 'hashes'],
                         'allowExtraFields' => true,
                     ]
                 ),


### PR DESCRIPTION
According to the specifications, the length and hashes fields should be optional and not forbidden (https://theupdateframework.github.io/specification/latest/#file-formats-snapshot). We worked with the tuf-go server package instead of the tuf-python package, and this approach breaks this workflow. Because it's not intended by the specifications either, I would not disallow these fields.